### PR TITLE
hotfix - remove blank div under marker cluster

### DIFF
--- a/assets/js/Leaflet.DonutCluster.js
+++ b/assets/js/Leaflet.DonutCluster.js
@@ -151,7 +151,6 @@
                     var t = e.target,
                         val = readable(d.value);
                     t.setAttribute('stroke-width', weight + 5);
-                    legend.setAttribute('class', 'legend');
                     div.zIndex = div.parentNode.style.zIndex;
                     div.parentNode.style.zIndex = 100000;
                     text.innerHTML = val;


### PR DESCRIPTION
hotfix
마커 클러스터 위에 마우스 올렸을 때 빈 div가 하나 생성되는 이슈가 있었습니다.
새로 오른쪽 아래에 범례를 추가하며 legend class가 겹쳤던게 원인이었습니다.